### PR TITLE
Implement acoustic simulator for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# Aural-Vista
-Room acoustics
+# Aural Vista
+
+A lightweight 3D acoustic simulator running entirely in the browser. Just clone and push to GitHub Pages.
+
+## Deploy
+1. Fork or clone this repository.
+2. Push changes to the `main` branch.
+3. In repo **Settings → Pages**, choose `Deploy from a branch` and select `main`.
+4. Your site will be available at `https://<username>.github.io/<repository>`.
+
+![Preview](https://placeholder.com/aural-vista-demo.gif)
+
+MIT License.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,79 @@
+body {
+    margin: 0;
+    font-family: 'Inter', sans-serif;
+    background: linear-gradient(135deg, #1e3c72, #2a5298);
+    color: #f0f0f0;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+.dark body {
+    background: linear-gradient(135deg, #0f2027, #203a43);
+}
+
+.panel {
+    display: flex;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    background: rgba(255,255,255,0.1);
+    backdrop-filter: blur(6px);
+    border-radius: 0 0 12px 12px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.panel label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.panel input {
+    margin-top: 0.25rem;
+    padding: 0.25rem;
+    background: rgba(0,0,0,0.1);
+    border: none;
+    border-radius: 4px;
+    color: #222;
+    font-weight: 400;
+}
+
+.panel button {
+    padding: 0.5rem 1rem;
+    background: #2563eb;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.panel button:hover {
+    background: #1d4ed8;
+}
+
+.flex-fill {
+    flex: 1;
+    position: relative;
+}
+
+canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: linear-gradient(135deg, #0f2027, #203a43);
+        color: #e0e0e0;
+    }
+    .panel {
+        background: rgba(0,0,0,0.3);
+    }
+    .panel input {
+        background: rgba(255,255,255,0.1);
+        color: #fff;
+    }
+}

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="8" fill="#2563eb" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Aural Vista - 3D Akustický Simulátor</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <meta property="og:title" content="Aural Vista">
+    <meta property="og:description" content="Interaktivní 3D akustický simulátor v prohlížeči">
+    <meta property="og:image" content="https://placeholder.com/aural-vista-preview.jpg">
+</head>
+<body>
+    <div id="control-panel" class="panel">
+        <label>Šířka X [m]
+            <input id="dim-x" type="number" min="1" step="0.1" value="5" title="Šířka místnosti v metrech">
+        </label>
+        <label>Výška Y [m]
+            <input id="dim-y" type="number" min="1" step="0.1" value="3" title="Výška místnosti v metrech">
+        </label>
+        <label>Hloubka Z [m]
+            <input id="dim-z" type="number" min="1" step="0.1" value="5" title="Hloubka místnosti v metrech">
+        </label>
+        <button id="render-btn">Renderovat scénu</button>
+    </div>
+    <div id="canvas-container" class="flex-fill">
+        <!-- Three.js canvas injected here -->
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/three@0.163/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.163/examples/js/controls/OrbitControls.js"></script>
+    <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,156 @@
+// Main module for Aural Vista
+
+// Global configuration and state
+const app = {
+    dimensions: { x: 5, y: 3, z: 5 },
+    scene: null,
+    camera: null,
+    renderer: null,
+    controls: null,
+    audio: { ctx: null },
+    container: document.getElementById('canvas-container'),
+};
+
+// Initialize renderer and canvas
+function initRenderer() {
+    app.renderer = new THREE.WebGLRenderer({ antialias: true });
+    app.renderer.setSize(app.container.clientWidth, app.container.clientHeight);
+    app.renderer.setPixelRatio(window.devicePixelRatio);
+    app.container.appendChild(app.renderer.domElement);
+}
+
+// Create or update the scene based on current dimensions
+function buildScene() {
+    if (!app.renderer) initRenderer();
+
+    app.scene = new THREE.Scene();
+    app.scene.fog = new THREE.Fog(0x000000, 10, 50);
+
+    const { x, y, z } = app.dimensions;
+
+    app.camera = new THREE.PerspectiveCamera(60, app.container.clientWidth / app.container.clientHeight, 0.1, 1000);
+    app.camera.position.set(x, y, z * 1.5);
+
+    app.controls = new THREE.OrbitControls(app.camera, app.renderer.domElement);
+
+    // Room box
+    const roomGeo = new THREE.BoxGeometry(x, y, z);
+    const roomMat = new THREE.MeshPhongMaterial({ color: 0x5596e6, transparent: true, opacity: 0.2, side: THREE.BackSide });
+    const room = new THREE.Mesh(roomGeo, roomMat);
+    app.scene.add(room);
+
+    // Grid helper
+    const grid = new THREE.GridHelper(x, x);
+    grid.position.y = -y / 2;
+    app.scene.add(grid);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.4);
+    app.scene.add(ambient);
+
+    const point = new THREE.PointLight(0xffffff, 0.8);
+    point.position.set(x / 2, y, z / 2);
+    app.scene.add(point);
+
+    animate();
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+    if (app.controls) app.controls.update();
+    if (app.renderer && app.scene && app.camera) {
+        app.renderer.render(app.scene, app.camera);
+    }
+}
+
+// Handle resizing
+window.addEventListener('resize', () => {
+    if (!app.renderer) return;
+    app.renderer.setSize(app.container.clientWidth, app.container.clientHeight);
+    app.camera.aspect = app.container.clientWidth / app.container.clientHeight;
+    app.camera.updateProjectionMatrix();
+});
+
+// Audio helper
+function playTone(position) {
+    if (!app.audio.ctx) app.audio.ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const ctx = app.audio.ctx;
+    const osc = ctx.createOscillator();
+    osc.frequency.value = 440;
+
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(1, ctx.currentTime);
+    gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.3);
+
+    const panner = ctx.createPanner();
+    panner.panningModel = 'HRTF';
+    panner.positionX.value = position.x;
+    panner.positionY.value = position.y;
+    panner.positionZ.value = position.z;
+
+    osc.connect(panner).connect(gain).connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.3);
+}
+
+function spawnMarker(point) {
+    const geometry = new THREE.SphereGeometry(0.1, 16, 16);
+    const material = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+    const marker = new THREE.Mesh(geometry, material);
+    marker.position.copy(point);
+    app.scene.add(marker);
+
+    // Visual sound wave
+    const waveGeo = new THREE.SphereGeometry(0.1, 16, 16);
+    const waveMat = new THREE.MeshBasicMaterial({ color: 0xffff00, transparent: true, opacity: 0.5, wireframe: true });
+    const wave = new THREE.Mesh(waveGeo, waveMat);
+    wave.position.copy(point);
+    app.scene.add(wave);
+
+    const start = performance.now();
+    function expand() {
+        const elapsed = performance.now() - start;
+        const t = elapsed / 300; // 0.3s animation
+        wave.scale.setScalar(1 + t * 5);
+        wave.material.opacity = Math.max(0, 0.5 - t);
+        if (t < 1) {
+            requestAnimationFrame(expand);
+        } else {
+            app.scene.remove(wave);
+        }
+    }
+    expand();
+
+    playTone(point);
+}
+
+// Convert click into 3D position inside the room (front wall intersection)
+function onClick(event) {
+    if (!app.scene) return;
+    const rect = app.renderer.domElement.getBoundingClientRect();
+    const mouse = new THREE.Vector2(
+        ((event.clientX - rect.left) / rect.width) * 2 - 1,
+        -((event.clientY - rect.top) / rect.height) * 2 + 1
+    );
+
+    const raycaster = new THREE.Raycaster();
+    raycaster.setFromCamera(mouse, app.camera);
+
+    const intersects = raycaster.intersectObjects(app.scene.children, true);
+    if (intersects.length > 0) {
+        spawnMarker(intersects[0].point);
+    }
+}
+
+// Render button action
+document.getElementById('render-btn').addEventListener('click', () => {
+    app.dimensions.x = parseFloat(document.getElementById('dim-x').value);
+    app.dimensions.y = parseFloat(document.getElementById('dim-y').value);
+    app.dimensions.z = parseFloat(document.getElementById('dim-z').value);
+    buildScene();
+    app.renderer.domElement.addEventListener('click', onClick);
+    if (app.audio.ctx) app.audio.ctx.resume();
+});
+
+// TODO:
+// - Reflect sound from walls for realism
+// - Implement Head-Related Transfer Function for panning


### PR DESCRIPTION
## Summary
- add modern landing page with gradient theme and OG tags
- implement configurable 3D room with Three.js
- play panned tone and show animated sound wave when clicking
- document simple GitHub Pages deployment
- remove PNG favicon and use SVG

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841d7a97210832d9afd201a0f2cd570