### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci --ignore-scripts || true
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: './dist'
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A lightweight 3D acoustic simulator running entirely in the browser. Just clone 
 
 ## Deploy
 1. Fork or clone this repository.
-2. Push changes to the `main` branch.
-3. In repo **Settings → Pages**, choose `Deploy from a branch` and select `main`.
-4. Your site will be available at `https://<username>.github.io/<repository>`.
+2. Enable GitHub Pages for the repository.
+3. Push changes to the `main` branch.
+4. The site will be built and deployed automatically by GitHub Actions.
+5. After the first successful run your site will be available at `https://<username>.github.io/<repository>`.
 
 ![Preview](https://placeholder.com/aural-vista-demo.gif)
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "aural-vista",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "mkdir -p dist && cp -r index.html css js favicon.svg dist/"
+  }
+}


### PR DESCRIPTION
## Summary
- add a workflow to build and deploy the site to GitHub Pages
- add minimal `package.json` and `.gitignore`
- update deployment instructions in `README.md`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841da9d628c832d8d218c712c1c77b2